### PR TITLE
Implement querying for fulltext matches.

### DIFF
--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -54,6 +54,7 @@ use types::{
     DatomsColumn,
     DatomsTable,
     EmptyBecause,
+    FulltextColumn,
     QualifiedAlias,
     QueryValue,
     SourceAlias,
@@ -365,6 +366,13 @@ impl ConjoiningClauses {
                     // We don't need to handle expansion of attributes here. The subquery that
                     // produces the variable projection will do so.
                     self.constrain_column_to_constant(table, column, bound_val);
+                },
+
+                Column::Fulltext(FulltextColumn::Rowid) |
+                Column::Fulltext(FulltextColumn::Text) => {
+                    // We never expose `rowid` via queries.  We do expose `text`, but only
+                    // indirectly, by joining against `datoms`.  Therefore, these are meaningless.
+                    unimplemented!()
                 },
 
                 Column::Fixed(DatomsColumn::ValueTypeTag) => {

--- a/query-algebrizer/src/clauses/where_fn.rs
+++ b/query-algebrizer/src/clauses/where_fn.rs
@@ -22,6 +22,7 @@ use mentat_query::{
     NonIntegerConstant,
     SrcVar,
     Variable,
+    VariableOrPlaceholder,
     WhereFn,
 };
 
@@ -37,7 +38,14 @@ use errors::{
 };
 
 use types::{
+    Column,
+    ColumnConstraint,
     ComputedTable,
+    DatomsColumn,
+    DatomsTable,
+    FulltextColumn,
+    QualifiedAlias,
+    QueryValue,
     SourceAlias,
     VariableColumn,
 };
@@ -154,6 +162,7 @@ impl ConjoiningClauses {
         // Because we'll be growing the set of built-in functions, handling each differently, and
         // ultimately allowing user-specified functions, we match on the function name first.
         match where_fn.operator.0.as_str() {
+            "fulltext" => self.apply_fulltext(schema, where_fn),
             "ground" => self.apply_ground(schema, where_fn),
             _ => bail!(ErrorKind::UnknownFunction(where_fn.operator.clone())),
         }
@@ -240,6 +249,172 @@ impl ConjoiningClauses {
         }
 
         self.from.push(SourceAlias(table, alias));
+
+        Ok(())
+    }
+
+
+    /// This function:
+    /// - Resolves variables and converts types to those more amenable to SQL.
+    /// - Ensures that the predicate functions name a known operator.
+    /// - Accumulates a `NumericInequality` constraint into the `wheres` list.
+    #[allow(unused_variables)]
+    pub fn apply_fulltext<'s>(&mut self, schema: &'s Schema, where_fn: WhereFn) -> Result<()> {
+        if where_fn.args.len() != 3 {
+            bail!(ErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
+        }
+
+        if where_fn.binding.is_empty() {
+            // The binding must introduce at least one bound variable.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+        }
+
+        if !where_fn.binding.is_valid() {
+            // The binding must not duplicate bound variables.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+        }
+
+        for var in &where_fn.binding.variables() {
+            if let &Some(ref var) = var {
+                if self.input_variables.contains(var) {
+                    bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::BoundInputVariable));
+                }
+            }
+        }
+
+        let bindings = match where_fn.binding {
+            Binding::BindRel(bindings) => {
+                if bindings.len() != 4 {
+                    bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(),
+                                                    BindingError::InvalidNumberOfBindings {
+                                                        number: bindings.len(),
+                                                        expected: 4,
+                                                    }));
+                }
+                bindings
+            },
+            Binding::BindScalar(_) |
+            Binding::BindTuple(_) |
+            Binding::BindColl(_) => bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
+        };
+
+        let mut args = where_fn.args.into_iter();
+
+        // TODO: process source variables.
+        match args.next().unwrap() {
+            FnArg::SrcVar(SrcVar::DefaultSrc) => {},
+            _ => bail!(ErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable".into(), 0)),
+        }
+
+        // TODO: accept placeholder and set of attributes.  Alternately, consider putting the search
+        // term before the attribute arguments and collect the (variadic) attributes into a set.
+        // let a: Entid  = self.resolve_attribute_argument(&where_fn.operator, 1, args.next().unwrap())?;
+        //
+        // TODO: allow non-constant attributes.
+        // TODO: improve the expression of this matching, possibly by using attribute_for_* uniformly.
+        let a = match args.next().unwrap() {
+            FnArg::Ident(i) => schema.get_entid(&i),
+            // Must be an entid.
+            FnArg::EntidOrInteger(e) => Some(e),
+            _ => None,
+        };
+
+        let a = a.ok_or(ErrorKind::InvalidArgument(where_fn.operator.clone(), "attribute".into(), 1))?;
+        let attribute = schema.attribute_for_entid(a).cloned().ok_or(ErrorKind::InvalidArgument(where_fn.operator.clone(), "attribute".into(), 1))?;
+
+        let fulltext_values = DatomsTable::FulltextValues;
+        let datoms_table = DatomsTable::Datoms;
+
+        let fulltext_values_alias = self.next_alias_for_table(fulltext_values);
+        let datoms_table_alias = self.next_alias_for_table(datoms_table);
+
+        self.from.push(SourceAlias(DatomsTable::FulltextValues, fulltext_values_alias.clone()));
+        self.from.push(SourceAlias(DatomsTable::Datoms, datoms_table_alias.clone()));
+
+        // TODO: constrain the type in the more general cases.
+        self.constrain_attribute(datoms_table_alias.clone(), a);
+
+        self.wheres.add_intersection(ColumnConstraint::Equals(
+            QualifiedAlias(datoms_table_alias.clone(), Column::Fixed(DatomsColumn::Value)),
+            QueryValue::Column(QualifiedAlias(fulltext_values_alias.clone(), Column::Fulltext(FulltextColumn::Rowid)))));
+
+        // `search` is either text or a variable.
+        let search: TypedValue = match args.next().unwrap() {
+            FnArg::Variable(in_var) => {
+                if !self.input_variables.contains(&in_var) {
+                    bail!(ErrorKind::UnboundVariable((*in_var.0).clone()));
+                }
+                match self.bound_value(&in_var) {
+                    Some(ref in_value) => in_value.clone(),
+                    None => bail!(ErrorKind::UnboundVariable((*in_var.0).clone())),
+                }
+            },
+            FnArg::Constant(NonIntegerConstant::Text(s)) => {
+                TypedValue::typed_string(s.as_str())
+            },
+            _ => bail!(ErrorKind::InvalidArgument(where_fn.operator.clone(), "string".into(), 2)),
+        };
+
+        // TODO: should we build the FQA in ::Matches, preventing nonsense like matching on ::Rowid?
+        let constraint = ColumnConstraint::Matches(QualifiedAlias(fulltext_values_alias.clone(), Column::Fulltext(FulltextColumn::Text)),
+                                                   QueryValue::TypedValue(search));
+        self.wheres.add_intersection(constraint);
+
+        if let VariableOrPlaceholder::Variable(ref var) = bindings[0] {
+            if self.bound_value(&var).is_some() || self.input_variables.contains(&var) {
+                bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::BoundInputVariable));
+            }
+            self.constrain_var_to_type(var.clone(), ValueType::Ref);
+
+            let entity_alias = QualifiedAlias(datoms_table_alias.clone(), Column::Fixed(DatomsColumn::Entity));
+            self.column_bindings.entry(var.clone()).or_insert(vec![]).push(entity_alias);
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = bindings[1] {
+            if self.bound_value(&var).is_some() || self.input_variables.contains(&var) {
+                bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::BoundInputVariable));
+            }
+            self.constrain_var_to_type(var.clone(), ValueType::String);
+
+            let value_alias = QualifiedAlias(fulltext_values_alias.clone(), Column::Fulltext(FulltextColumn::Text));
+            self.column_bindings.entry(var.clone()).or_insert(vec![]).push(value_alias);
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = bindings[2] {
+            if self.bound_value(&var).is_some() || self.input_variables.contains(&var) {
+                bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::BoundInputVariable));
+            }
+            self.constrain_var_to_type(var.clone(), ValueType::Ref);
+
+            let tx_alias = QualifiedAlias(datoms_table_alias.clone(), Column::Fixed(DatomsColumn::Tx));
+            self.column_bindings.entry(var.clone()).or_insert(vec![]).push(tx_alias);
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = bindings[3] {
+            if self.bound_value(&var).is_some() || self.input_variables.contains(&var) {
+                bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::BoundInputVariable));
+            }
+            self.constrain_var_to_type(var.clone(), ValueType::Double);
+
+            // Right now we don't support binding a column to a constant value.  Therefore, we
+            // introduce a computed table with exactly the constant value we require.  See the
+            // translate tests for some edge cases in this space.
+            // TODO: optimize this by binding the value, like:
+            // self.value_bindings.insert(var.clone(), TypedValue::Double(0.0.into()));
+            // TODO: produce real scores using SQLite's matchinfo.
+            let names: Vec<Variable> = vec![var.clone()];
+            let named_values = ComputedTable::NamedValues {
+                names: names.clone(),
+                values: vec![vec![TypedValue::Double(0.0.into())]],
+            };
+            let table = self.computed_tables.push_computed(named_values);
+            let alias = self.next_alias_for_table(table);
+
+            // Stitch the computed table into column_bindings, so we get cross-linking.
+            self.bind_column_to_var(schema, alias.clone(), VariableColumn::Variable(var.clone()), var.clone());
+
+            self.from.push(SourceAlias(table, alias.clone()));
+        }
 
         Ok(())
     }
@@ -388,5 +563,74 @@ mod testing {
         assert_eq!(known_types.len(), 1);
         assert_eq!(known_types.get(&vz).expect("to know the type of ?z"),
                    &ValueTypeSet::of_one(ValueType::Long));
+    }
+
+
+    #[test]
+    fn test_apply_fulltext() {
+        let mut cc = ConjoiningClauses::default();
+        let mut schema = Schema::default();
+
+        associate_ident(&mut schema, NamespacedKeyword::new("foo", "fts"), 100);
+        add_attribute(&mut schema, 100, Attribute {
+            value_type: ValueType::String,
+            index: true,
+            fulltext: true,
+            ..Default::default()
+        });
+
+        let op = PlainSymbol::new("fulltext");
+        cc.apply_fulltext(&schema, WhereFn {
+            operator: op,
+            args: vec![
+                FnArg::SrcVar(SrcVar::DefaultSrc),
+                FnArg::Ident(NamespacedKeyword::new("foo", "fts")),
+                FnArg::Constant(NonIntegerConstant::Text(Rc::new("needle".into()))),
+            ],
+            binding: Binding::BindRel(vec![VariableOrPlaceholder::Variable(Variable::from_valid_name("?entity")),
+                                           VariableOrPlaceholder::Variable(Variable::from_valid_name("?value")),
+                                           VariableOrPlaceholder::Variable(Variable::from_valid_name("?tx")),
+                                           VariableOrPlaceholder::Variable(Variable::from_valid_name("?score"))]),
+        }).expect("to be able to apply_fulltext");
+
+        assert!(!cc.is_known_empty());
+
+        // Finally, expand column bindings.
+        cc.expand_column_bindings();
+        assert!(!cc.is_known_empty());
+
+        let clauses = cc.wheres;
+        assert_eq!(clauses.len(), 3);
+
+        assert_eq!(clauses.0[0], ColumnConstraint::Equals(QualifiedAlias("datoms01".to_string(), Column::Fixed(DatomsColumn::Attribute)),
+                                                          QueryValue::Entid(100)).into());
+        assert_eq!(clauses.0[1], ColumnConstraint::Equals(QualifiedAlias("datoms01".to_string(), Column::Fixed(DatomsColumn::Value)),
+                                                          QueryValue::Column(QualifiedAlias("fulltext_values00".to_string(), Column::Fulltext(FulltextColumn::Rowid)))).into());
+        assert_eq!(clauses.0[2], ColumnConstraint::Matches(QualifiedAlias("fulltext_values00".to_string(), Column::Fulltext(FulltextColumn::Text)),
+                                                           QueryValue::TypedValue(TypedValue::String(Rc::new("needle".into())))).into());
+
+        let bindings = cc.column_bindings;
+        assert_eq!(bindings.len(), 4);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?entity")).expect("column binding for ?entity").clone(),
+                   vec![QualifiedAlias("datoms01".to_string(), Column::Fixed(DatomsColumn::Entity))]);
+        assert_eq!(bindings.get(&Variable::from_valid_name("?value")).expect("column binding for ?value").clone(),
+                   vec![QualifiedAlias("fulltext_values00".to_string(), Column::Fulltext(FulltextColumn::Text))]);
+        assert_eq!(bindings.get(&Variable::from_valid_name("?tx")).expect("column binding for ?tx").clone(),
+                   vec![QualifiedAlias("datoms01".to_string(), Column::Fixed(DatomsColumn::Tx))]);
+        assert_eq!(bindings.get(&Variable::from_valid_name("?score")).expect("column binding for ?score").clone(),
+                   vec![QualifiedAlias("c00".to_string(), Column::Variable(VariableColumn::Variable(Variable::from_valid_name("?score"))))]);
+
+        let known_types = cc.known_types;
+        assert_eq!(known_types.len(), 4);
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?entity")).expect("known types for ?entity").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+        assert_eq!(known_types.get(&Variable::from_valid_name("?value")).expect("known types for ?value").clone(),
+                   vec![ValueType::String].into_iter().collect());
+        assert_eq!(known_types.get(&Variable::from_valid_name("?tx")).expect("known types for ?tx").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+        assert_eq!(known_types.get(&Variable::from_valid_name("?score")).expect("known types for ?score").clone(),
+                   vec![ValueType::Double].into_iter().collect());
     }
 }

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -24,6 +24,12 @@ pub enum BindingError {
     RepeatedBoundVariable, // TODO: include repeated variable(s).
     // Like `... :in ?x :where [(f) ?x] ...`.
     BoundInputVariable, // TODO: include bound variable(s).
+    // Expected [[?x ?y]] but got some other type of binding.  Mentat is deliberately more strict
+    // than Datomic: we won't try to make sense of non-obvious (and potentially erroneous) bindings.
+    ExpectedBindRel,
+    // Expected [?x1 ... ?xN] or [[?x1 ... ?xN]] but got some other number of bindings.  Mentat is
+    // deliberately more strict than Datomic: we prefer placeholders to omission.
+    InvalidNumberOfBindings { number: usize, expected: usize },
 }
 
 error_chain! {

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -213,6 +213,7 @@ pub use types::{
     ComputedTable,
     DatomsColumn,
     DatomsTable,
+    FulltextColumn,
     OrderBy,
     QualifiedAlias,
     QueryValue,

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -84,6 +84,12 @@ pub enum DatomsColumn {
     Tx,
     ValueTypeTag,
 }
+/// One of the named columns of our fulltext values table.
+#[derive(PartialEq, Eq, Clone)]
+pub enum FulltextColumn {
+    Rowid,
+    Text,
+}
 
 #[derive(PartialEq, Eq, Clone)]
 pub enum VariableColumn {
@@ -94,6 +100,7 @@ pub enum VariableColumn {
 #[derive(PartialEq, Eq, Clone)]
 pub enum Column {
     Fixed(DatomsColumn),
+    Fulltext(FulltextColumn),
     Variable(VariableColumn),
 }
 
@@ -157,8 +164,31 @@ impl Debug for Column {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             &Column::Fixed(ref c) => c.fmt(f),
+            &Column::Fulltext(ref c) => c.fmt(f),
             &Column::Variable(ref v) => v.fmt(f),
         }
+    }
+}
+
+impl FulltextColumn {
+    pub fn as_str(&self) -> &'static str {
+        use self::FulltextColumn::*;
+        match *self {
+            Rowid => "rowid",
+            Text => "text",
+        }
+    }
+}
+
+impl ColumnName for FulltextColumn {
+    fn column_name(&self) -> String {
+        self.as_str().to_string()
+    }
+}
+
+impl Debug for FulltextColumn {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -300,6 +330,9 @@ pub enum ColumnConstraint {
     },
     HasType(TableAlias, ValueType),
     NotExists(ComputedTable),
+    // TODO: Merge this with NumericInequality?  I expect the fine-grained information to be
+    // valuable when optimizing.
+    Matches(QualifiedAlias, QueryValue),
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -410,6 +443,10 @@ impl Debug for ColumnConstraint {
                 write!(f, "{:?} {:?} {:?}", left, operator, right)
             },
 
+            &Matches(ref qa, ref thing) => {
+                write!(f, "{:?} MATCHES {:?}", qa, thing)
+            },
+
             &HasType(ref qa, value_type) => {
                 write!(f, "{:?}.value_type_tag = {:?}", qa, value_type)
             },
@@ -425,6 +462,7 @@ pub enum EmptyBecause {
     // Var, existing, desired.
     TypeMismatch(Variable, ValueTypeSet, ValueType),
     NoValidTypes(Variable),
+    NonAttributeArgument,
     NonNumericArgument,
     NonStringFulltextValue,
     UnresolvedIdent(NamespacedKeyword),
@@ -445,6 +483,9 @@ impl Debug for EmptyBecause {
             },
             &NoValidTypes(ref var) => {
                 write!(f, "Type mismatch: {:?} has no valid types", var)
+            },
+            &NonAttributeArgument => {
+                write!(f, "Non-attribute argument in attribute place")
             },
             &NonNumericArgument => {
                 write!(f, "Non-numeric argument in numeric place")
@@ -557,5 +598,30 @@ impl ValueTypeSet {
 
     pub fn is_unit(&self) -> bool {
         self.0.len() == 1
+    }
+}
+
+impl IntoIterator for ValueTypeSet {
+    type Item = ValueType;
+    type IntoIter = ::enum_set::Iter<ValueType>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl ::std::iter::FromIterator<ValueType> for ValueTypeSet {
+    fn from_iter<I: IntoIterator<Item = ValueType>>(iterator: I) -> Self {
+        let mut ret = Self::none();
+        ret.0.extend(iterator);
+        ret
+    }
+}
+
+impl ::std::iter::Extend<ValueType> for ValueTypeSet {
+    fn extend<I: IntoIterator<Item = ValueType>>(&mut self, iter: I) {
+        for element in iter {
+            self.0.insert(element);
+        }
     }
 }

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -149,6 +149,14 @@ impl ToConstraint for ColumnConstraint {
                 }
             },
 
+            Matches(left, right) => {
+                Constraint::Infix {
+                    op: Op("MATCH"),
+                    left: ColumnOrExpression::Column(left),
+                    right: right.into(),
+                }
+            },
+
             HasType(table, value_type) => {
                 let column = QualifiedAlias::new(table, DatomsColumn::ValueTypeTag).to_column();
                 Constraint::equal(column, ColumnOrExpression::Integer(value_type.value_type_tag()))

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -69,6 +69,13 @@ fn prepopulated_typed_schema(foo_type: ValueType) -> Schema {
         value_type: foo_type,
         ..Default::default()
     });
+    associate_ident(&mut schema, NamespacedKeyword::new("foo", "fts"), 100);
+    add_attribute(&mut schema, 100, Attribute {
+        value_type: ValueType::String,
+        index: true,
+        fulltext: true,
+        ..Default::default()
+    });
     schema
 }
 
@@ -685,4 +692,36 @@ fn test_binding_input_variable() {
         mentat_query_algebrizer::ErrorKind::InvalidBinding(_, mentat_query_algebrizer::BindingError::BoundInputVariable) => {},
         _ => assert!(false),
     }
+}
+
+#[test]
+fn test_fulltext() {
+    let schema = prepopulated_typed_schema(ValueType::Double);
+
+    let query = r#"[:find ?entity ?value ?tx ?score :where [(fulltext $ :foo/fts "needle") [[?entity ?value ?tx ?score]]]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT `datoms01`.e AS `?entity`, `fulltext_values00`.text AS `?value`, `datoms01`.tx AS `?tx`, `c00`.`?score` AS `?score` FROM `fulltext_values` AS `fulltext_values00`, `datoms` AS `datoms01`, (SELECT 0 AS `?score` WHERE 0 UNION ALL VALUES (0)) AS `c00` WHERE `datoms01`.a = 100 AND `datoms01`.v = `fulltext_values00`.rowid AND `fulltext_values00`.text MATCH $v0");
+    assert_eq!(args, vec![make_arg("$v0", "needle"),]);
+
+    let query = r#"[:find ?entity ?value ?tx :where [(fulltext $ :foo/fts "needle") [[?entity ?value ?tx ?score]]]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    // Observe that the computed table isn't dropped, even though `?score` isn't bound in the final conjoining clause.
+    assert_eq!(sql, "SELECT DISTINCT `datoms01`.e AS `?entity`, `fulltext_values00`.text AS `?value`, `datoms01`.tx AS `?tx` FROM `fulltext_values` AS `fulltext_values00`, `datoms` AS `datoms01`, (SELECT 0 AS `?score` WHERE 0 UNION ALL VALUES (0)) AS `c00` WHERE `datoms01`.a = 100 AND `datoms01`.v = `fulltext_values00`.rowid AND `fulltext_values00`.text MATCH $v0");
+    assert_eq!(args, vec![make_arg("$v0", "needle"),]);
+
+    let query = r#"[:find ?entity ?value ?tx :where [(fulltext $ :foo/fts "needle") [[?entity ?value ?tx _]]]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    // Observe that the computed table isn't included at all when `?score` isn't bound.
+    assert_eq!(sql, "SELECT DISTINCT `datoms01`.e AS `?entity`, `fulltext_values00`.text AS `?value`, `datoms01`.tx AS `?tx` FROM `fulltext_values` AS `fulltext_values00`, `datoms` AS `datoms01` WHERE `datoms01`.a = 100 AND `datoms01`.v = `fulltext_values00`.rowid AND `fulltext_values00`.text MATCH $v0");
+    assert_eq!(args, vec![make_arg("$v0", "needle"),]);
+
+    let query = r#"[:find ?entity ?value ?tx :where [(fulltext $ :foo/fts "needle") [[?entity ?value ?tx ?score]]] [?entity :foo/bar ?score]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT `datoms01`.e AS `?entity`, `fulltext_values00`.text AS `?value`, `datoms01`.tx AS `?tx` FROM `fulltext_values` AS `fulltext_values00`, `datoms` AS `datoms01`, (SELECT 0 AS `?score` WHERE 0 UNION ALL VALUES (0)) AS `c00`, `datoms` AS `datoms02` WHERE `datoms01`.a = 100 AND `datoms01`.v = `fulltext_values00`.rowid AND `fulltext_values00`.text MATCH $v0 AND `datoms02`.a = 99 AND `datoms01`.e = `datoms02`.e AND `c00`.`?score` = `datoms02`.v");
+    assert_eq!(args, vec![make_arg("$v0", "needle"),]);
+
+    let query = r#"[:find ?entity ?value ?tx :where [?entity :foo/bar ?score] [(fulltext $ :foo/fts "needle") [[?entity ?value ?tx ?score]]]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?entity`, `fulltext_values01`.text AS `?value`, `datoms02`.tx AS `?tx` FROM `datoms` AS `datoms00`, `fulltext_values` AS `fulltext_values01`, `datoms` AS `datoms02`, (SELECT 0 AS `?score` WHERE 0 UNION ALL VALUES (0)) AS `c00` WHERE `datoms00`.a = 99 AND `datoms02`.a = 100 AND `datoms02`.v = `fulltext_values01`.rowid AND `fulltext_values01`.text MATCH $v0 AND `datoms00`.e = `datoms02`.e AND `datoms00`.v = `c00`.`?score`");
+    assert_eq!(args, vec![make_arg("$v0", "needle"),]);
 }


### PR DESCRIPTION
This is just one possible approach.  It would be possible to always
produce a computed table, which might be simpler: there would be no
new column types, and there wouldn't be the awkward VALUES table for
`?score`.  On the other hand, this approach follows the
Clojure{Script} implementation, and, if `?score` is not bound, is
likely to be queried more efficiently by SQLite.